### PR TITLE
PHP 8.4 compatibility fixes

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -486,7 +486,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostsSettings, $hostIndex, ?array $variables = null)
     {
         if (null === $variables) {
             $variables = [];


### PR DESCRIPTION
Fixes PHP warning "Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead."